### PR TITLE
Fix compile error: missing dependency of 'dubbo-config-spring'

### DIFF
--- a/springboot-dubbo-seata/pom.xml
+++ b/springboot-dubbo-seata/pom.xml
@@ -145,6 +145,12 @@
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo-config-spring</artifactId>
+            <version>${dubbo.version}</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
The 'springboot-dubbo-seata' examples use '@EnableDubbo' annotation which exists in 'dubbo-config-spring'.