### PR TITLE
update seata samples for docker (#80)

### DIFF
--- a/springboot-dubbo-fescar/pom.xml
+++ b/springboot-dubbo-fescar/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <fescar.version>0.2.1</fescar.version>
+        <fescar.version>0.4.1</fescar.version>
         <druid.version>1.1.10</druid.version>
         <mybatis.version>1.3.2</mybatis.version>
         <mybatis-plus.version>2.3</mybatis-plus.version>

--- a/springboot-dubbo-fescar/samples-account/Dockerfile
+++ b/springboot-dubbo-fescar/samples-account/Dockerfile
@@ -1,0 +1,12 @@
+# 选择JDK
+FROM openjdk:8u212-jre-slim-stretch
+VOLUME /tmp
+ADD target/samples-account-1.0.0-SNAPSHOT.jar app.jar
+RUN sh -c 'touch /app.jar'
+ENV JAVA_OPTS=""
+ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]
+# 命令行
+# 构建 docker build -t samples-account:1.0.0 .
+# 测试运行 docker run --net=host samples-account:1.0.0 /bin/bash
+# 进入bash docker exec -it [container_id] bash
+# 后台运行(开发) docker run -d --net=host samples-account:1.0.0

--- a/springboot-dubbo-fescar/samples-account/pom.xml
+++ b/springboot-dubbo-fescar/samples-account/pom.xml
@@ -95,6 +95,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/springboot-dubbo-fescar/samples-account/src/main/resources/application.properties
+++ b/springboot-dubbo-fescar/samples-account/src/main/resources/application.properties
@@ -7,18 +7,18 @@ dubbo.application.name= account-gts-fescar-example
 dubbo.protocol.id=dubbo
 dubbo.protocol.name=dubbo
 dubbo.registry.id=dubbo-account-fescar
-dubbo.registry.address=nacos://127.0.0.1:8848
+dubbo.registry.address=nacos://nacos:8848
 dubbo.protocol.port=20880
 dubbo.application.qosEnable=false
 
 #===================================registry config==========================================
 #Nacos\u6CE8\u518C\u4E2D\u5FC3
-spring.cloud.nacos.discovery.server-addr=127.0.0.1:8848
+spring.cloud.nacos.discovery.server-addr=nacos:8848
 management.endpoints.web.exposure.include=*
 
 #====================================mysql config============================================
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/db_gts_fescar?useSSL=false&useUnicode=true&characterEncoding=utf-8&allowMultiQueries=true
+spring.datasource.url=jdbc:mysql://mysql:3306/db_gts_fescar?useSSL=false&useUnicode=true&characterEncoding=utf-8&allowMultiQueries=true
 spring.datasource.username=root
 spring.datasource.password=root
 

--- a/springboot-dubbo-fescar/samples-account/src/main/resources/file.conf
+++ b/springboot-dubbo-fescar/samples-account/src/main/resources/file.conf
@@ -24,7 +24,7 @@ service {
   #vgroup->rgroup
   vgroup_mapping.my_test_tx_group = "default"
   #only support single node
-  default.grouplist = "127.0.0.1:8091"
+  default.grouplist = "fescar:8091"
   #degrade current not support
   enableDegrade = false
   #disable

--- a/springboot-dubbo-fescar/samples-account/src/main/resources/registry.conf
+++ b/springboot-dubbo-fescar/samples-account/src/main/resources/registry.conf
@@ -3,7 +3,7 @@ registry {
   type = "file"
 
   nacos {
-    serverAddr = "localhost"
+    serverAddr = "nacos"
     namespace = "public"
     cluster = "default"
   }

--- a/springboot-dubbo-fescar/samples-dubbo-business-call/Dockerfile
+++ b/springboot-dubbo-fescar/samples-dubbo-business-call/Dockerfile
@@ -1,0 +1,12 @@
+# 选择JDK
+FROM openjdk:8u212-jre-slim-stretch
+VOLUME /tmp
+ADD target/samples-dubbo-business-call-1.0.0-SNAPSHOT.jar app.jar
+RUN sh -c 'touch /app.jar'
+ENV JAVA_OPTS=""
+ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]
+# 命令行
+# 构建 docker build -t samples-dubbo-business-call:1.0.0 .
+# 测试运行 docker run --net=host samples-dubbo-business-call:1.0.0 /bin/bash
+# 进入bash docker exec -it [container_id] bash
+# 后台运行(开发) docker run -d --net=host samples-dubbo-business-call:1.0.0

--- a/springboot-dubbo-fescar/samples-dubbo-business-call/pom.xml
+++ b/springboot-dubbo-fescar/samples-dubbo-business-call/pom.xml
@@ -83,6 +83,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/springboot-dubbo-fescar/samples-dubbo-business-call/src/main/resources/application.properties
+++ b/springboot-dubbo-fescar/samples-dubbo-business-call/src/main/resources/application.properties
@@ -8,11 +8,11 @@ dubbo.protocol.id=dubbo
 dubbo.protocol.name=dubbo
 dubbo.protocol.port=10001
 dubbo.registry.id=dubbo-gts-fescar
-dubbo.registry.address=nacos://127.0.0.1:8848
+dubbo.registry.address=nacos://nacos:8848
 dubbo.provider.version=1.0.0
 dubbo.application.qosEnable=false
 
 #==================================nacos==============================================
-spring.cloud.nacos.discovery.server-addr=127.0.0.1:8848
+spring.cloud.nacos.discovery.server-addr=nacos:8848
 management.endpoints.web.exposure.include=*
 

--- a/springboot-dubbo-fescar/samples-dubbo-business-call/src/main/resources/file.conf
+++ b/springboot-dubbo-fescar/samples-dubbo-business-call/src/main/resources/file.conf
@@ -24,7 +24,7 @@ service {
   #vgroup->rgroup
   vgroup_mapping.my_test_tx_group = "default"
   #only support single node
-  default.grouplist = "127.0.0.1:8091"
+  default.grouplist = "fescar:8091"
   #degrade current not support
   enableDegrade = false
   #disable

--- a/springboot-dubbo-fescar/samples-dubbo-business-call/src/main/resources/registry.conf
+++ b/springboot-dubbo-fescar/samples-dubbo-business-call/src/main/resources/registry.conf
@@ -3,7 +3,7 @@ registry {
   type = "file"
 
   nacos {
-    serverAddr = "localhost"
+    serverAddr = "nacos"
     namespace = "public"
     cluster = "default"
   }

--- a/springboot-dubbo-fescar/samples-order/Dockerfile
+++ b/springboot-dubbo-fescar/samples-order/Dockerfile
@@ -1,0 +1,12 @@
+# 选择JDK
+FROM openjdk:8u212-jre-slim-stretch
+VOLUME /tmp
+ADD target/samples-order-1.0.0-SNAPSHOT.jar app.jar
+RUN sh -c 'touch /app.jar'
+ENV JAVA_OPTS=""
+ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]
+# 命令行
+# 构建 docker build -t samples-order:1.0.0 .
+# 测试运行 docker run --net=host samples-order:1.0.0 /bin/bash
+# 进入bash docker exec -it [container_id] bash
+# 后台运行(开发) docker run -d --net=host samples-order:1.0.0

--- a/springboot-dubbo-fescar/samples-order/pom.xml
+++ b/springboot-dubbo-fescar/samples-order/pom.xml
@@ -100,6 +100,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/springboot-dubbo-fescar/samples-order/src/main/resources/application.properties
+++ b/springboot-dubbo-fescar/samples-order/src/main/resources/application.properties
@@ -7,18 +7,18 @@ dubbo.application.name= order-gts-fescar-example
 dubbo.protocol.id=dubbo
 dubbo.protocol.name=dubbo
 dubbo.registry.id=dubbo-order-fescar
-dubbo.registry.address=nacos://127.0.0.1:8848
+dubbo.registry.address=nacos://nacos:8848
 dubbo.protocol.port=20881
 dubbo.application.qosEnable=false
 
 #===================================registry config==========================================
 #Nacos\u6CE8\u518C\u4E2D\u5FC3
-spring.cloud.nacos.discovery.server-addr=127.0.0.1:8848
+spring.cloud.nacos.discovery.server-addr=nacos:8848
 management.endpoints.web.exposure.include=*
 
 #====================================mysql =============================================
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/db_gts_fescar?useSSL=false&useUnicode=true&characterEncoding=utf-8&allowMultiQueries=true
+spring.datasource.url=jdbc:mysql://mysql:3306/db_gts_fescar?useSSL=false&useUnicode=true&characterEncoding=utf-8&allowMultiQueries=true
 spring.datasource.username=root
 spring.datasource.password=root
 

--- a/springboot-dubbo-fescar/samples-order/src/main/resources/file.conf
+++ b/springboot-dubbo-fescar/samples-order/src/main/resources/file.conf
@@ -24,7 +24,7 @@ service {
   #vgroup->rgroup
   vgroup_mapping.my_test_tx_group = "default"
   #only support single node
-  default.grouplist = "127.0.0.1:8091"
+  default.grouplist = "fescar:8091"
   #degrade current not support
   enableDegrade = false
   #disable

--- a/springboot-dubbo-fescar/samples-order/src/main/resources/registry.conf
+++ b/springboot-dubbo-fescar/samples-order/src/main/resources/registry.conf
@@ -3,7 +3,7 @@ registry {
   type = "file"
 
   nacos {
-    serverAddr = "localhost"
+    serverAddr = "nacos"
     namespace = "public"
     cluster = "default"
   }

--- a/springboot-dubbo-fescar/samples-storage/Dockerfile
+++ b/springboot-dubbo-fescar/samples-storage/Dockerfile
@@ -1,0 +1,12 @@
+# 选择JDK
+FROM openjdk:8u212-jre-slim-stretch
+VOLUME /tmp
+ADD target/samples-storage-1.0.0-SNAPSHOT.jar app.jar
+RUN sh -c 'touch /app.jar'
+ENV JAVA_OPTS=""
+ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]
+# 命令行
+# 构建 docker build -t samples-storage:1.0.0 .
+# 测试运行 docker run --net=host samples-storage:1.0.0 /bin/bash
+# 进入bash docker exec -it [container_id] bash
+# 后台运行(开发) docker run -d --net=host samples-storage:1.0.0

--- a/springboot-dubbo-fescar/samples-storage/pom.xml
+++ b/springboot-dubbo-fescar/samples-storage/pom.xml
@@ -100,6 +100,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/springboot-dubbo-fescar/samples-storage/src/main/resources/application.properties
+++ b/springboot-dubbo-fescar/samples-storage/src/main/resources/application.properties
@@ -7,18 +7,18 @@ dubbo.application.name= storage-gts-fescar-example
 dubbo.protocol.id=dubbo
 dubbo.protocol.name=dubbo
 dubbo.registry.id=dubbo-storage-fescar
-dubbo.registry.address=nacos://127.0.0.1:8848
+dubbo.registry.address=nacos://nacos:8848
 dubbo.protocol.port=20882
 dubbo.application.qosEnable=false
 
 #===================================registry config==========================================
 #Nacos\u6CE8\u518C\u4E2D\u5FC3
-spring.cloud.nacos.discovery.server-addr=127.0.0.1:8848
+spring.cloud.nacos.discovery.server-addr=nacos:8848
 management.endpoints.web.exposure.include=*
 
 #====================================mysql config===========================================
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/db_gts_fescar?useSSL=false&useUnicode=true&characterEncoding=utf-8&allowMultiQueries=true
+spring.datasource.url=jdbc:mysql://mysql:3306/db_gts_fescar?useSSL=false&useUnicode=true&characterEncoding=utf-8&allowMultiQueries=true
 spring.datasource.username=root
 spring.datasource.password=root
 

--- a/springboot-dubbo-fescar/samples-storage/src/main/resources/file.conf
+++ b/springboot-dubbo-fescar/samples-storage/src/main/resources/file.conf
@@ -24,7 +24,7 @@ service {
   #vgroup->rgroup
   vgroup_mapping.my_test_tx_group = "default"
   #only support single node
-  default.grouplist = "127.0.0.1:8091"
+  default.grouplist = "fescar:8091"
   #degrade current not support
   enableDegrade = false
   #disable

--- a/springboot-dubbo-fescar/samples-storage/src/main/resources/registry.conf
+++ b/springboot-dubbo-fescar/samples-storage/src/main/resources/registry.conf
@@ -3,7 +3,7 @@ registry {
   type = "file"
 
   nacos {
-    serverAddr = "localhost"
+    serverAddr = "nacos"
     namespace = "public"
     cluster = "default"
   }


### PR DESCRIPTION
SpringCloud-eureka-seata 启动报错
1.需要在每个客户端加上@EnableDiscoveryClient @EnableEurekaClient这俩个注解
2.在eureka的pom.xml文件中加上
 <!-- jaxb模块引用 - start -->
        <dependency>
            <groupId>javax.xml.bind</groupId>
            <artifactId>jaxb-api</artifactId>
        </dependency>
        <dependency>
            <groupId>com.sun.xml.bind</groupId>
            <artifactId>jaxb-impl</artifactId>
            <version>2.3.0</version>
        </dependency>
        <dependency>
            <groupId>org.glassfish.jaxb</groupId>
            <artifactId>jaxb-runtime</artifactId>
            <version>2.3.0</version>
        </dependency>
        <dependency>
            <groupId>javax.activation</groupId>
            <artifactId>activation</artifactId>
            <version>1.1.1</version>
        </dependency>
        <!-- jaxb模块引用 - end -->