### PR TITLE
bugfix: resolve the "storage" and "order" data be inconsistent

### DIFF
--- a/springboot-mybatis/sbm-storage-service/src/main/java/io/seata/samples/storage/persistence/StorageMapper.java
+++ b/springboot-mybatis/sbm-storage-service/src/main/java/io/seata/samples/storage/persistence/StorageMapper.java
@@ -12,7 +12,7 @@ public interface StorageMapper {
 
     Storage findByCommodityCode(@Param("commodityCode") String commodityCode);
 
-    int updateById(Storage record);
+    int updateById(@Param("id") Integer id, @Param("count") Integer count);
 
     void insert(Storage record);
 

--- a/springboot-mybatis/sbm-storage-service/src/main/java/io/seata/samples/storage/service/StorageService.java
+++ b/springboot-mybatis/sbm-storage-service/src/main/java/io/seata/samples/storage/service/StorageService.java
@@ -23,8 +23,7 @@ public class StorageService {
 
     public void deduct(String commodityCode, int count) {
         Storage storage = storageMapper.findByCommodityCode(commodityCode);
-        storage.setCount(storage.getCount() - count);
-        storageMapper.updateById(storage);
+        storageMapper.updateById(storage.getId(), count);
     }
 
     @GlobalLock

--- a/springboot-mybatis/sbm-storage-service/src/main/resources/mapper/StorageMapper.xml
+++ b/springboot-mybatis/sbm-storage-service/src/main/resources/mapper/StorageMapper.xml
@@ -18,7 +18,7 @@
     </select>
 
     <update id="updateById">
-        update storage_tbl set count = #{count,jdbcType=INTEGER}
+        update storage_tbl set count = count - ${count}
         WHERE id = #{id}
     </update>
 


### PR DESCRIPTION
Checking the data first and then updating it will cause the read data to be not real-time data. After testing, under multi-threaded conditions, the original code will cause the "storage" and "order" data to be inconsistent. The modified code solved the problem