### PR TITLE
optimize:fix timeout exception

### DIFF
--- a/springcloud-eureka-feign-mybatis-seata/account-server/src/main/resources/application.yml
+++ b/springcloud-eureka-feign-mybatis-seata/account-server/src/main/resources/application.yml
@@ -5,6 +5,12 @@ eureka:
     client:
         serviceUrl:
             defaultZone: http://${eureka.instance.hostname}:8761/eureka/
+feign:
+    client:
+        config:
+            default:
+                connectTimeout: 5000
+                readTimeout: 10000
 logging:
     level:
         io:

--- a/springcloud-eureka-feign-mybatis-seata/order-server/src/main/resources/application.yml
+++ b/springcloud-eureka-feign-mybatis-seata/order-server/src/main/resources/application.yml
@@ -8,6 +8,11 @@ eureka:
 feign:
     hystrix:
         enabled: false
+    client:
+        config:
+            default:
+                connectTimeout: 5000
+                readTimeout: 10000
 logging:
     level:
         io:


### PR DESCRIPTION
In the example, the call chain is too long to time out. feign will retry and again time out, confuse people.