### PR TITLE
bugfix: fix jackson dependency conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <mysql-connector.version>5.1.44</mysql-connector.version>
         <curator.version>4.2.0</curator.version>
         <guava.version>27.0.1-jre</guava.version>
-        <jackson.version>2.10.0.pr1</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <druid.version>1.1.12</druid.version>
     </properties>
     <modules>


### PR DESCRIPTION
SpringBoot +dubbo的exmaple中，jackson 版本冲突导致项目无法启动