### PR TITLE
bugfix: fix the use of condition variable in keep()

### DIFF
--- a/dubbo/src/main/java/io/seata/samples/dubbo/ApplicationKeeper.java
+++ b/dubbo/src/main/java/io/seata/samples/dubbo/ApplicationKeeper.java
@@ -52,9 +52,9 @@ public class ApplicationKeeper {
                 } catch (Exception e) {
                     LOGGER.error("Failed to close ApplicationContext", e);
                 }
-
+                
+                LOCK.lock();
                 try {
-                    LOCK.lock();
                     STOP.signal();
                 } finally {
                     LOCK.unlock();
@@ -67,13 +67,14 @@ public class ApplicationKeeper {
      * Keep.
      */
     public void keep() {
-        synchronized (LOCK) {
-            try {
-                LOGGER.info("Application is keep running ... ");
-                STOP.wait();
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
+        LOCK.lock();
+        try {  
+            LOGGER.info("Application is keep running ... ");
+            STOP.await();
+        } catch (InterruptedException e) {
+            LOGGER.error("ApplicationKeeper.keep() is interrupted by InterruptedException!", e);
+        } finally {
+            LOCK.unlock();
         }
     }
 }

--- a/dubbo/src/main/java/io/seata/samples/dubbo/ApplicationKeeper.java
+++ b/dubbo/src/main/java/io/seata/samples/dubbo/ApplicationKeeper.java
@@ -70,7 +70,7 @@ public class ApplicationKeeper {
         synchronized (LOCK) {
             try {
                 LOGGER.info("Application is keep running ... ");
-                LOCK.wait();
+                STOP.wait();
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Suspend the main thread with ReentrantLock's condition variable and wait until the main thread is gracefully shut down before waking up.
Lock is an instance of ReentrantLock, and STOP is the Condition variable of Lock.
So, LOCK.wait(); should be changed to STOP.wait ();