### PR TITLE
optimize:  add missing column gmt_updated

### DIFF
--- a/saga/dubbo-saga-sample/src/main/resources/sql/h2_init.sql
+++ b/saga/dubbo-saga-sample/src/main/resources/sql/h2_init.sql
@@ -52,6 +52,7 @@ create table if not exists seata_state_inst
     output_params            clob comment 'output parameters',
     status                   varchar(2)   not null comment 'status(SU succeed|FA failed|UN unknown|SK skipped|RU running)',
     excep                    blob comment 'exception',
+    gmt_updated              timestamp(3) comment 'update time',
     gmt_end                  timestamp(3) comment 'end time',
     primary key (id, machine_inst_id)
 );

--- a/saga/local-saga-sample/src/main/resources/sql/h2_init.sql
+++ b/saga/local-saga-sample/src/main/resources/sql/h2_init.sql
@@ -52,6 +52,7 @@ create table if not exists seata_state_inst
     output_params            clob comment 'output parameters',
     status                   varchar(2)   not null comment 'status(SU succeed|FA failed|UN unknown|SK skipped|RU running)',
     excep                    blob comment 'exception',
+    gmt_updated              timestamp(3) comment 'update time',
     gmt_end                  timestamp(3) comment 'end time',
     primary key (id, machine_inst_id)
 );

--- a/saga/sofarpc-saga-sample/src/main/resources/sql/h2_init.sql
+++ b/saga/sofarpc-saga-sample/src/main/resources/sql/h2_init.sql
@@ -52,6 +52,7 @@ create table if not exists seata_state_inst
     output_params            clob comment 'output parameters',
     status                   varchar(2)   not null comment 'status(SU succeed|FA failed|UN unknown|SK skipped|RU running)',
     excep                    blob comment 'exception',
+    gmt_updated              timestamp(3) comment 'update time',
     gmt_end                  timestamp(3) comment 'end time',
     primary key (id, machine_inst_id)
 );


### PR DESCRIPTION
add missing column gmt_updated with table seata_state_inst
在 saga 模块中，建表语句补上缺少的 gmt_updated 字段

fixes #451 