### PR TITLE
修改了spring-context-support的版本，删除了spring-context-support重复的依赖

### DIFF
--- a/dubbo/pom.xml
+++ b/dubbo/pom.xml
@@ -48,10 +48,6 @@
             <artifactId>spring-context-support</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.alibaba.spring</groupId>
-            <artifactId>spring-context-support</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <aopalliance.version>1.0</aopalliance.version>
         <zkclient.version>0.10</zkclient.version>
         <dubbo.registry.nacos>0.0.2</dubbo.registry.nacos>
-        <spring-context-support.version>1.0.6</spring-context-support.version>
+        <spring-context-support.version>1.0.11</spring-context-support.version>
         <testng.version>6.4</testng.version>
         <protobuf.version>3.16.1</protobuf.version>
         <spring.version>5.1.3.RELEASE</spring.version>


### PR DESCRIPTION
1. spring-context-support 1.0.6 和 dubbo 2.7.15的版本不兼容，启动报错
2. 删除了对spring-context-support重复的依赖