### PR TITLE
Could io.seata:nutzboot-dubbo-fescar-common:1.1.0 drop off redundant dependencies?

### DIFF
--- a/nutzboot-dubbo-fescar/nutzboot-dubbo-fescar-common/pom.xml
+++ b/nutzboot-dubbo-fescar/nutzboot-dubbo-fescar-common/pom.xml
@@ -8,5 +8,54 @@
     </parent>
     <artifactId>nutzboot-dubbo-fescar-common</artifactId>
     <dependencies>
+        <dependency>
+            <groupId>com.alibaba.fescar</groupId>
+            <artifactId>fescar-dubbo-alibaba</artifactId>
+            <version>0.4.2</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.nutz</groupId>
+            <artifactId>nutzboot-starter-nutz-dao</artifactId>
+            <version>2.3.3.v20190329</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.nutz</groupId>
+            <artifactId>nutzboot-core</artifactId>
+            <version>2.3.3.v20190329</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.25</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.nutz</groupId>
+            <artifactId>nutzboot-starter-fescar</artifactId>
+            <version>2.3.3.v20190329</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.nutz</groupId>
+            <artifactId>nutzboot-starter-jdbc</artifactId>
+            <version>2.3.3.v20190329</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.nutz</groupId>
+            <artifactId>nutzboot-starter-dubbo</artifactId>
+            <version>2.3.3.v20190329</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/163913307-57eeca2b-4307-4841-924c-be4c27fbf32b.png)
This figure presents the dependency tree between multiple modules in **_nutzboot-dubbo-seata_**. As shown in this figure, 
##
org.apache.commons:commons-lang3:jar:3.4:compile
com.alibaba.fescar:fescar-rm-datasource:jar:0.4.1:compile
io.netty:netty:jar:3.7.0.Final:compile
com.fasterxml.jackson.core:jackson-annotations:jar:2.9.4:runtime
joda-time:joda-time:jar:2.3:runtime
commons-configuration:commons-configuration:jar:1.8:runtime
org.javassist:javassist:jar:3.20.0-GA:compile
aopalliance:aopalliance:jar:1.0:compile
com.alibaba.fescar:fescar-tcc:jar:0.4.1:compile
com.netflix.netflix-commons:netflix-infix:jar:0.3.0:runtime
org.nutz:nutzboot-core:jar:2.3.3.v20190329:compile
com.alibaba:dubbo:jar:2.6.6:compile
org.antlr:stringtemplate:jar:3.2.1:runtime
org.apache.commons:commons-math:jar:2.2:runtime
org.apache.zookeeper:zookeeper:jar:3.4.8:compile
com.github.andrewoma.dexx:dexx-collections:jar:0.2:runtime
org.apache.httpcomponents:httpcore:jar:4.4.6:runtime
com.fasterxml.jackson.core:jackson-core:jar:2.9.4:runtime
com.google.code.findbugs:jsr305:jar:3.0.1:runtime
commons-logging:commons-logging:jar:1.2:runtime
org.nutz:nutzboot-starter-nutz-dao:jar:2.3.3.v20190329:compile
org.apache.commons:commons-pool2:jar:2.4.2:compile
org.ow2.asm:asm:jar:4.2:compile
com.thoughtworks.xstream:xstream:jar:1.4.10:runtime
com.alibaba.nacos:nacos-api:jar:0.8.0:compile
org.apache.httpcomponents:httpclient:jar:4.5.3:runtime
com.netflix.eureka:eureka-client:jar:1.9.5:compile
jline:jline:jar:0.9.94:compile
org.slf4j:slf4j-log4j12:jar:1.7.25:compile
org.hdrhistogram:HdrHistogram:jar:2.1.9:compile
commons-lang:commons-lang:jar:2.6:compile
com.sun.jersey:jersey-core:jar:1.19.1:runtime
javax.ws.rs:jsr311-api:jar:1.1.1:runtime
io.micrometer:micrometer-core:jar:1.1.1:compile
org.codehaus.jettison:jettison:jar:1.3.7:runtime
com.typesafe:config:jar:1.2.1:compile
javax.inject:javax.inject:jar:1:compile
com.alibaba:fastjson:jar:1.2.48:compile
org.springframework:spring-aop:jar:4.3.16.RELEASE:compile
org.springframework:spring-expression:jar:4.3.16.RELEASE:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
commons-io:commons-io:jar:2.2:compile
com.google.guava:guava:jar:18.0:compile
com.sun.jersey.contribs:jersey-apache-client4:jar:1.19.1:runtime
javax.servlet:servlet-api:jar:2.5:runtime
com.alibaba.nacos:nacos-common:jar:0.8.0:compile
com.alibaba.fescar:fescar-dubbo-alibaba:jar:0.4.2:compile
org.nutz:nutzboot-starter-dubbo:jar:2.3.3.v20190329:compile
stax:stax-api:jar:1.0.1:runtime
org.antlr:antlr-runtime:jar:3.4:runtime
com.sun.jersey:jersey-client:jar:1.19.1:runtime
org.apache.curator:curator-framework:jar:4.0.1:compile
com.alibaba.nacos:nacos-client:jar:0.8.0:compile
com.google.inject:guice:jar:4.1.0:compile
com.fasterxml.jackson.core:jackson-databind:jar:2.9.4:runtime
log4j:log4j:jar:1.2.17:compile
com.alibaba:druid:jar:1.1.14:compile
com.alibaba.fescar:fescar-config:jar:0.4.1:compile
com.google.code.gson:gson:jar:2.8.0:compile
antlr:antlr:jar:2.7.7:runtime
org.nutz:nutz-integration-dubbo:jar:1.r.68.v20190329:compile
org.nutz:nutzboot-starter-jdbc:jar:2.3.3.v20190329:compile
org.slf4j:jcl-over-slf4j:jar:1.7.25:compile
xmlpull:xmlpull:jar:1.1.3.1:runtime
com.alibaba.fescar:fescar-spring:jar:0.4.1:compile
redis.clients:jedis:jar:2.9.0:compile
org.nutz:nutz:jar:1.r.68.v20190329:compile
commons-jxpath:commons-jxpath:jar:1.3:runtime
com.alibaba.fescar:fescar-core:jar:0.4.1:compile
commons-codec:commons-codec:jar:1.11:compile
org.jboss.netty:netty:jar:3.2.5.Final:compile
com.ctrip.framework.apollo:apollo-core:jar:1.1.0:compile
org.springframework:spring-beans:jar:4.3.16.RELEASE:compile
com.ctrip.framework.apollo:apollo-client:jar:1.1.0:compile
org.apache.curator:curator-client:jar:4.0.1:compile
com.netflix.archaius:archaius-core:jar:0.7.6:compile
org.nutz:nutzboot-starter-fescar:jar:2.3.3.v20190329:compile
org.springframework:spring-context:jar:4.3.16.RELEASE:compile
org.springframework:spring-core:jar:4.3.16.RELEASE:compile
org.nutz:nutz-plugins-daocache:jar:1.r.68.v20190329:compile
com.netflix.servo:servo-core:jar:0.12.21:runtime
xpp3:xpp3_min:jar:1.1.4c:runtime
commons-pool:commons-pool:jar:1.6:compile
com.github.vlsi.compactmap:compactmap:jar:1.2.1:runtime
com.alibaba.fescar:fescar-tm:jar:0.4.2:compile
com.alibaba.fescar:fescar-common:jar:0.4.1:compile
cglib:cglib:jar:3.1:compile
com.101tec:zkclient:jar:0.10:compile
com.alibaba.fescar:fescar-rm:jar:0.4.1:compile
org.slf4j:slf4j-api:jar:1.7.25:compile
org.latencyutils:LatencyUtils:jar:2.0.3:compile
com.netflix.netflix-commons:netflix-eventbus:jar:0.3.0:runtime
org.codehaus.jackson:jackson-mapper-lgpl:jar:1.9.6:compile
com.alibaba.fescar:fescar-discovery:jar:0.4.1:compile
org.codehaus.jackson:jackson-core-lgpl:jar:1.9.6:compile

---

**_DependencyVO_** in **_nutzboot-dubbo-fescar-common, nutzboot-dubbo-fescar-web, nutzboot-dubbo-fescar-order, nutzboot-dubbo-fescar-account, nutzboot-dubbo-fescar-stock_** are inherited from their parent module. However, it is not used by **_nutzboot-dubbo-fescar-common_**. We can perform refactoring operations in the pom, by removing such redundant dependencies in **_nutzboot-dubbo-fescar-common_**.

Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_com.alibaba.nacos:nacos-api:jar:0.8.0:compile_** incorporates a high-level vulnerability SNYK-JAVA-COMALIBABANACOS-1014641. one of the redundant dependencies **_com.google.guava:guava:jar:18.0:compile_** incorporates a medium-level vulnerability SNYK-JAVA-COMGOOGLEGUAVA-1015415. one of the redundant dependencies **_com.alibaba.nacos:nacos-common:jar:0.8.0:compile_** incorporates a high-level vulnerability SNYK-JAVA-COMALIBABANACOS-1277194. one of the redundant dependencies **_com.thoughtworks.xstream:xstream:jar:1.4.10:runtime_** incorporates a high-level vulnerability SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1040458. one of the redundant dependencies **_org.apache.httpcomponents:httpclient:jar:4.5.3:runtime_** incorporates a medium-level vulnerability SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-1048058. one of the redundant dependencies **_commons-io:commons-io:jar:2.2:compile_** incorporates a medium-level vulnerability SNYK-JAVA-COMMONSIO-1277109. one of the redundant dependencies **_com.alibaba:fastjson:jar:1.2.48:compile_** incorporates a high-level vulnerability SNYK-JAVA-COMALIBABA-570967. one of the redundant dependencies **_log4j:log4j:jar:1.2.17:compile_** incorporates a critical-level vulnerability SNYK-JAVA-LOG4J-572732. one of the redundant dependencies **_com.google.code.gson:gson:jar:2.8.0:compile_** incorporates a high-level vulnerability SNYK-JAVA-COMGOOGLECODEGSON-1730327. As such, I suggest a refactoring operation for **_io.seata:nutzboot-dubbo-fescar-common:1.1.0_**’s pom file.
