### PR TITLE
fix: fix e2e test github action docker-compose version to V1

### DIFF
--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -24,6 +24,18 @@ jobs:
       fail-fast: false
       max-parallel: 2
     steps:
+      - name: Uninstall Docker Compose v2
+        run: sudo rm -f /usr/local/bin/docker-compose
+
+      - name: Install Docker Compose v1
+        run: |
+          DOCKER_COMPOSE_VERSION=1.29.2
+          sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+
+      - name: Verify Docker Compose v1 installation
+        run: docker-compose --version
+
       - name: Check out code into
         uses: actions/checkout@v3
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
The ubuntu-latest version use docker-compose v2 version, we need to use  docker-compose v1 version to run e2e test

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

