### PR TITLE
optimize: add docker-compose for AT samples and improve README

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,10 +26,15 @@ jobs:
           for dir in "${directories[@]}"; do
             for subdir in "$dir"/*; do
               if [ -d "$subdir" ]; then
-                echo "Entering directory $subdir"
-                cd "$subdir"
-                mvn -B test
-                cd - > /dev/null
+                # Check if pom.xml exists before running Maven
+                if [ -f "$subdir/pom.xml" ]; then
+                  echo "Entering directory $subdir"
+                  cd "$subdir"
+                  mvn -B test
+                  cd - > /dev/null
+                else
+                  echo "Skipping $subdir (no pom.xml found)"
+                fi
               fi
             done
           done

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -24,17 +24,8 @@ jobs:
       fail-fast: false
       max-parallel: 2
     steps:
-      - name: Uninstall Docker Compose v2
-        run: sudo rm -f /usr/local/bin/docker-compose
-
-      - name: Install Docker Compose v1
-        run: |
-          DOCKER_COMPOSE_VERSION=1.29.2
-          sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-
-      - name: Verify Docker Compose v1 installation
-        run: docker-compose --version
+      - name: Verify Docker Compose installation
+        run: docker compose version
 
       - name: Check out code into
         uses: actions/checkout@v3

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -24,8 +24,17 @@ jobs:
       fail-fast: false
       max-parallel: 2
     steps:
-      - name: Verify Docker Compose installation
-        run: docker compose version
+      - name: Uninstall Docker Compose v2
+        run: sudo rm -f /usr/local/bin/docker-compose
+
+      - name: Install Docker Compose v1
+        run: |
+          DOCKER_COMPOSE_VERSION=1.29.2
+          sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+
+      - name: Verify Docker Compose v1 installation
+        run: docker-compose --version
 
       - name: Check out code into
         uses: actions/checkout@v3
@@ -46,7 +55,7 @@ jobs:
       - name: Add script directory to PATH
         run: |
           cd skywalking-infra-e2e/bin/linux
-          echo "$(pwd)" >> $GITHUB_PATH
+          echo "export PATH=$PATH:$(pwd)" >> $GITHUB_PATH
           chmod 777 e2e
           cp e2e /usr/local/bin
 

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Add script directory to PATH
         run: |
           cd skywalking-infra-e2e/bin/linux
-          echo "export PATH=$PATH:$(pwd)" >> $GITHUB_PATH
+          echo "$(pwd)" >> $GITHUB_PATH
           chmod 777 e2e
           cp e2e /usr/local/bin
 

--- a/README.md
+++ b/README.md
@@ -15,37 +15,66 @@
     limitations under the License.
 -->
 
-# samples code specification
+# Apache Seata(incubating) Samples
 
-##  Directory Structure
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Seata](https://img.shields.io/badge/Seata-2.x-orange.svg)](https://seata.apache.org/)
+[![Java](https://img.shields.io/badge/Java-8%2B-green.svg)](https://www.oracle.com/java/)
+[![Docker](https://img.shields.io/badge/Docker-Compose-2496ED.svg)](https://docs.docker.com/compose/)
+[![GitHub Stars](https://img.shields.io/github/stars/apache/incubator-seata?style=social)](https://github.com/apache/incubator-seata/stargazers)
+[![GitHub Forks](https://img.shields.io/github/forks/apache/incubator-seata?style=social)](https://github.com/apache/incubator-seata/network/members)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/apache/incubator-seata-samples/pulls)
 
-The first and second levels are more of a directory
+This repository contains sample projects demonstrating how to use [Apache Seata](https://seata.apache.org/) distributed transaction solutions.
 
-Top level: seata-samples
+## Transaction Modes
 
-Second layer: at-sample, tcc-sample, saga-sample, xa-sample
+Seata supports four transaction modes. Learn more at the [Quick Start Guide](https://seata.apache.org/docs/user/quickstart/).
 
-Third floor, The third layer is the specific sample and the naming convention is as follows:
+| Mode | Directory | Description |
+|------|-----------|-------------|
+| AT | `at-sample/` | Automatic Transaction mode (recommended for most cases) |
+| TCC | `tcc-sample/` | Try-Confirm-Cancel mode |
+| Saga | `saga-sample/` | Long-running transaction mode |
+| XA | `xa-sample/` | XA distributed transaction mode |
 
-## naming
+## Prerequisites
 
-naming with framework: spring-nacos-seata, springboot-naocs-zk-seata ...
+- JDK 8 or later
+- Maven 3.6+
+- Docker & Docker Compose (for local development)
 
-## dependency
+## Quick Start (Local Development)
 
-pom: The dependencies of each sample should be independent and should not depend on the dependencies of the parent pom of seata samples.
+We provide `docker-compose.yaml` files to help you quickly set up the required infrastructure.
 
+### AT Mode Samples
+```bash
+cd at-sample
+docker-compose up -d
+```
+This starts MySQL (with tables initialized), Zookeeper, and Seata Server. You can then run any AT sub-sample in your IDE.
 
+> **Note:** The `seata-e2e.yaml` files are for CI/CD integration tests. For local development, use `docker-compose.yaml`.
 
-# samples transaction model
-https://seata.apache.org/docs/user/quickstart/
+After infrastructure is up, start the Java applications in your IDE. Refer to each sample's documentation for specific startup order.
 
-## start sequence
+## Directory Structure
 
-1、account
+```
+seata-samples/
+├── at-sample/           # AT mode samples
+│   ├── springboot-dubbo-seata/
+│   ├── spring-dubbo-seata/
+│   └── ...
+├── tcc-sample/          # TCC mode samples
+├── saga-sample/         # Saga mode samples
+├── saga-annotation-sample/ # Saga annotation mode samples
+├── xa-sample/           # XA mode samples
+└── e2e-test/            # E2E testing framework
+```
 
-2、storage
+## For Contributors
 
-3、order
-
-4、business
+- **Naming**: Use framework combination naming, e.g., `spring-nacos-seata`, `springboot-nacos-zk-seata`
+- **Dependency**: Each sample should have independent dependencies and should NOT depend on the parent pom

--- a/at-sample/docker-compose.yaml
+++ b/at-sample/docker-compose.yaml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Docker Compose for AT mode samples local development
+# Usage: docker-compose up -d
+# This will start MySQL (with tables initialized), Zookeeper, and Seata Server.
+
+services:
+  mysql:
+    image: mysql:5.7
+    platform: linux/amd64
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=123456
+      - MYSQL_DATABASE=seata
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d
+
+  zookeeper:
+    image: zookeeper:3.8.4
+    ports:
+      - "2181:2181"
+
+  seata-server:
+    image: apache/seata-server:2.3.0
+    platform: linux/amd64
+    ports:
+      - "8091:8091"
+      - "7091:7091"
+    environment:
+      - SEATA_PORT=8091
+      - STORE_MODE=file

--- a/at-sample/docker-compose.yaml
+++ b/at-sample/docker-compose.yaml
@@ -45,3 +45,4 @@ services:
     environment:
       - SEATA_PORT=8091
       - STORE_MODE=file
+

--- a/at-sample/sql/init.sql
+++ b/at-sample/sql/init.sql
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Business tables for AT mode samples
+
+CREATE TABLE `account_tbl`
+(
+    `id`      int(11) NOT NULL AUTO_INCREMENT,
+    `user_id` varchar(255) DEFAULT NULL,
+    `money`   int(11) DEFAULT '0',
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+
+CREATE TABLE `stock_tbl`
+(
+    `id`             int(11) NOT NULL AUTO_INCREMENT,
+    `commodity_code` varchar(255) DEFAULT NULL,
+    `count`          int(11) DEFAULT '0',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `commodity_code` (`commodity_code`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+
+CREATE TABLE `order_tbl`
+(
+    `id`             int(11) NOT NULL AUTO_INCREMENT,
+    `user_id`        varchar(255) DEFAULT NULL,
+    `commodity_code` varchar(255) DEFAULT NULL,
+    `count`          int(11) DEFAULT '0',
+    `money`          int(11) DEFAULT '0',
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+
+-- Seata AT mode undo_log table
+
+CREATE TABLE IF NOT EXISTS `undo_log`
+(
+    `branch_id`     BIGINT       NOT NULL COMMENT 'branch transaction id',
+    `xid`           VARCHAR(128) NOT NULL COMMENT 'global transaction id',
+    `context`       VARCHAR(128) NOT NULL COMMENT 'undo_log context,such as serialization',
+    `rollback_info` LONGBLOB     NOT NULL COMMENT 'rollback info',
+    `log_status`    INT(11)      NOT NULL COMMENT '0:normal status,1:defense status',
+    `log_created`   DATETIME(6)  NOT NULL COMMENT 'create datetime',
+    `log_modified`  DATETIME(6)  NOT NULL COMMENT 'modify datetime',
+    UNIQUE KEY `ux_undo_log` (`xid`, `branch_id`)
+) ENGINE = InnoDB AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4 COMMENT ='AT transaction mode undo table';
+
+ALTER TABLE `undo_log` ADD INDEX `ix_log_created` (`log_created`);
+
+-- Test data for springboot-dubbo-seata sample
+-- Used by: E2EController.testCommit() and E2EController.testRollback()
+-- Scenario: User U100001 purchases commodity C00321
+
+INSERT INTO `account_tbl` (`user_id`, `money`) VALUES ('U100001', 10000);
+INSERT INTO `stock_tbl` (`commodity_code`, `count`) VALUES ('C00321', 100);


### PR DESCRIPTION

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
1. **Adding [docker-compose.yaml]** to `at-sample/` directory
   - Starts MySQL (with tables initialized), Zookeeper, and Seata Server
   - One command to set up all infrastructure for any AT sub-sample
2. **Adding shared SQL init script** ([at-sample/sql/init.sql](cci:7://file:///Users/mini/Desktop/github/incubator-seata-samples/at-sample/sql/init.sql:0:0-0:0))
   - Creates `account_tbl`, `stock_tbl`, `order_tbl`, and `undo_log` tables
   - Includes test data for the springboot-dubbo-seata sample

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

