### PR TITLE
feature: Enhance e2e Testing

### DIFF
--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -1,48 +1,46 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "Seata E2E Test"
 
-on: [ push,pull_request ]
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
   run_e2e:
-    name: Run E2E Test (Build JDK${{ matrix.build_jdk }}, Docker JDK${{ matrix.docker_jdk }})
+    name: E2E ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env:
       DEBIAN_FRONTEND: noninteractive
     strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-        # Build JDK version - used for Maven compilation
-        build_jdk: [ 8, 11, 17 ]
-        # Docker JDK version - used in Docker images for runtime
-        docker_jdk: [ 8, 11, 17 ]
-        # Exclude some combinations to reduce test time
-        exclude:
-          # When building with JDK 8, skip testing with JDK 17
-          - build_jdk: 8
-            docker_jdk: 17
-          - build_jdk: 8
-            docker_jdk: 11
-          - build_jdk: 11
-            docker_jdk: 8
-          - build_jdk: 11
-            docker_jdk: 17
-          - build_jdk: 17
-            docker_jdk: 8
-          - build_jdk: 17
-            docker_jdk: 11
       fail-fast: false
       max-parallel: 3
+      matrix:
+        include:
+          - name: jdk8-mysql57-amd64
+            os: ubuntu-latest
+            build_jdk: 8
+            runtime_jdk_image: eclipse-temurin:8-jdk-alpine
+            mysql_image: mysql:5.7
+            mysql_connector_version: 8.0.31
+            platform: linux/amd64
+          - name: jdk11-mysql80-amd64
+            os: ubuntu-latest
+            build_jdk: 11
+            runtime_jdk_image: eclipse-temurin:11-jdk-alpine
+            mysql_image: mysql:8.0
+            mysql_connector_version: 8.0.33
+            platform: linux/amd64
+          - name: jdk17-mysql80-amd64
+            os: ubuntu-latest
+            build_jdk: 17
+            runtime_jdk_image: eclipse-temurin:17-jdk-alpine
+            mysql_image: mysql:8.0
+            mysql_connector_version: 8.0.33
+            platform: linux/amd64
+          - name: jdk17-mysql80-arm64
+            os: ubuntu-latest
+            build_jdk: 17
+            runtime_jdk_image: eclipse-temurin:17-jdk-alpine
+            mysql_image: mysql:8.0
+            mysql_connector_version: 8.0.33
+            platform: linux/arm64
     steps:
       - name: Uninstall Docker Compose v2
         run: sudo rm -f /usr/local/bin/docker-compose
@@ -56,24 +54,23 @@ jobs:
       - name: Verify Docker Compose v1 installation
         run: docker-compose --version
 
-      # ========== 新增步骤1：Docker环境全量检查（关键） ==========
-      - name: Check Docker environment (debug)
+      - name: Set up QEMU for cross-platform containers
+        if: matrix.platform != 'linux/amd64'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Check Docker environment
         run: |
-          # 检查Docker服务状态
           sudo systemctl status docker || true
-          # 检查Docker版本和Compose版本
           docker --version
           docker-compose --version
-          # 检查磁盘空间（GitHub Runner空间不足会导致镜像/容器创建失败）
+          docker info
           df -h
-          # 检查已有容器/镜像（清理残留）
           docker ps -a
           docker images
-          # 检查端口占用（排查Seata常用端口8091/7091等）
           sudo lsof -i :8091 || true
           sudo lsof -i :7091 || true
 
-      - name: Check out code into
+      - name: Check out code
         uses: actions/checkout@v3
 
       - name: Clone skywalking e2e repository
@@ -87,7 +84,9 @@ jobs:
 
       - name: Build e2e framework (use skywalking-infra-e2e v1.3.0)
         run: |
-          cd skywalking-infra-e2e && git checkout 1485ae03f0ad90496ad7626a5ae4a6a73a1f6296 && make linux
+          cd skywalking-infra-e2e
+          git checkout 1485ae03f0ad90496ad7626a5ae4a6a73a1f6296
+          make linux
 
       - name: Add script directory to PATH
         run: |
@@ -102,105 +101,84 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.build_jdk }}
 
-      - name: Set Docker JDK base image
+      - name: Set E2E environment matrix
         run: |
           echo "=========================================="
           echo "E2E Test Configuration:"
+          echo "Matrix Name: ${{ matrix.name }}"
           echo "Build JDK Version: ${{ matrix.build_jdk }}"
-          echo "Docker Runtime JDK Version: ${{ matrix.docker_jdk }}"
+          echo "Docker Runtime JDK Image: ${{ matrix.runtime_jdk_image }}"
+          echo "MySQL Image: ${{ matrix.mysql_image }}"
+          echo "MySQL Connector Version: ${{ matrix.mysql_connector_version }}"
+          echo "Docker Platform: ${{ matrix.platform }}"
           echo "=========================================="
-          echo "E2E_JDK_BASE_IMAGE=${{ matrix.docker_jdk }}" >> $GITHUB_ENV
+          echo "E2E_JDK_BASE_IMAGE=${{ matrix.runtime_jdk_image }}" >> $GITHUB_ENV
+          echo "E2E_MYSQL_IMAGE=${{ matrix.mysql_image }}" >> $GITHUB_ENV
+          echo "E2E_MYSQL_CONNECTOR_VERSION=${{ matrix.mysql_connector_version }}" >> $GITHUB_ENV
+          echo "E2E_DOCKER_PLATFORM=${{ matrix.platform }}" >> $GITHUB_ENV
 
-      - name: prepare e2e tests
+      - name: Prepare e2e tests
         run: |
-          cd e2e-test/scripts && sh prepare-test.sh
-          # ========== 新增：打印prepare阶段的Docker状态 ==========
+          cd e2e-test/scripts
+          sh prepare-test.sh
 
-      - name: check docker resources after prepare-test.sh
+      - name: Check docker resources after prepare-test.sh
         run: |
           echo "===== After prepare-test.sh: Docker containers status ====="
           docker ps -a
           echo "===== After prepare-test.sh: Docker images status ====="
           docker images
 
-      # ========== 新增关键步骤：手动执行docker-compose up -d（抓原始错误） ==========
-      - name: Manual run docker-compose up -d (debug core error)
-        run: |
-          cd e2e-test/scripts
-          # 1. 先检查compose文件语法（关键！语法错会直接exit 1）
-          echo "===== Check docker-compose.yml syntax ====="
-          docker-compose config --verbose
-          # 2. 手动执行up -d，输出最详细日志，强制捕获错误
-          echo "===== Run docker-compose up -d with debug ====="
-          docker-compose up -d --verbose 2>&1 | tee docker-compose-up-debug.log
-          # 3. 检查执行结果，打印错误码
-          COMPOSE_EXIT_CODE=${PIPESTATUS[0]}
-          echo "===== Docker-compose exit code: $COMPOSE_EXIT_CODE ====="
-          # 4. 如果失败，立即打印容器状态和日志
-          if [ $COMPOSE_EXIT_CODE -ne 0 ]; then
-            echo "===== Docker containers status after failed up ====="
-            docker ps -a
-            echo "===== Docker-compose logs after failed up ====="
-            docker-compose logs
-            # 强制退出，让步骤失败（方便看日志）
-            exit $COMPOSE_EXIT_CODE
-          fi
-
-      # ========== 原有e2e测试步骤（保留，用于对比） ==========
-      - name: run e2e tests (auto answer [yN] prompt)
+      - name: Run e2e tests
         id: e2e_test
         run: |
           set -euo pipefail
           cd e2e-test/scripts
-          # 核心：用echo y | 自动回答[yN]的交互提示（关键！）
-          # 原理：把y作为输入，直接传给test-run.sh执行的进程，绕过手动输入
           sh test-run.sh 2>&1 | tee e2e-test-log.txt
-          # 捕获真实退出码（排除echo的干扰）
-          TEST_EXIT_CODE=${PIPESTATUS[1]}  # 注意：这里从0改成1，因为管道是echo y | sh ...，PIPESTATUS[1]才是sh的退出码
+          TEST_EXIT_CODE=${PIPESTATUS[0]}
           exit $TEST_EXIT_CODE
 
-      # ========== 核心修正2：日志收集改为if: always()（无论成败都执行） ==========
       - name: Collect debug logs
-        if: always()  # 替代failure()，无论上一步成功/失败都执行
+        if: always()
         run: |
           echo "===== Docker version info ====="
           docker --version
           docker-compose --version
-          
+
           echo "===== All Docker containers status ====="
           docker ps -a
-          
+
           echo "===== Docker compose logs ====="
-          # 进入e2e脚本目录，执行docker-compose logs（适配你的compose文件路径）
-          cd e2e-test/scripts
-          docker-compose logs || true
-          
-          echo "===== Seata container logs (if exists) ====="
-          # 查找Seata相关容器并打印日志（适配容器名）
-          SEATA_CONTAINER=$(docker ps -a | grep seata-server | awk '{print $1}')
-          if [ -n "$SEATA_CONTAINER" ]; then
-            docker logs $SEATA_CONTAINER || true
+          if [ -d tmp/scene-test ]; then
+            find tmp/scene-test -name docker-compose.yaml -print0 | while IFS= read -r -d '' compose_file; do
+              scene_dir=$(dirname "$compose_file")
+              echo "===== Logs for ${scene_dir} ====="
+              (cd "${scene_dir}" && docker-compose logs --tail=100) || true
+            done
+          else
+            echo "tmp/scene-test does not exist"
           fi
-          
+
+          echo "===== Seata container logs (if exists) ====="
+          SEATA_CONTAINERS=$(docker ps -a --filter "name=seata-server" -q || true)
+          if [ -n "$SEATA_CONTAINERS" ]; then
+            for container in $SEATA_CONTAINERS; do
+              docker logs "$container" || true
+            done
+          fi
+
           echo "===== E2E test script logs ====="
-          cat e2e-test-log.txt || true
-          
+          cat e2e-test/scripts/e2e-test-log.txt || true
+
           echo "===== Port usage ====="
           sudo lsof -i -P -n | grep LISTEN || true
 
-      # ========== 核心修正3：日志上传也改为if: always() ==========
       - name: Upload debug logs
-        if: always()  # 无论成败都上传日志（失败时必传，成功时可选）
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-debug-logs-${{ matrix.build_jdk }}
+          name: e2e-debug-logs-${{ matrix.name }}
           path: |
             e2e-test/scripts/e2e-test-log.txt
-            /var/log/docker.log || true
-
-      # ========== 核心修正4：手动标记Job失败（如果测试步骤失败） ==========
-      - name: Mark job as failed if test failed
-        if: steps.e2e_test.outcome == 'failure'
-        run: |
-          echo "E2E test failed, marking job as failed"
-          exit 1
+            tmp/scene-test/**/docker-compose.yaml
+            tmp/scene-test/**/e2e.yaml

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -63,16 +63,21 @@ jobs:
             platform: linux/arm64
             experimental: true
     steps:
-      - name: Uninstall Docker Compose v2
-        run: sudo rm -f /usr/local/bin/docker-compose
-
-      - name: Install Docker Compose v1
+      - name: Install Docker Compose command
         run: |
-          DOCKER_COMPOSE_VERSION=1.29.2
-          sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo rm -f /usr/local/bin/docker-compose
+          if [ "$(uname -m)" = "x86_64" ]; then
+            DOCKER_COMPOSE_VERSION=1.29.2
+            sudo curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          else
+            sudo tee /usr/local/bin/docker-compose > /dev/null <<'EOF'
+          #!/usr/bin/env bash
+          docker compose "$@"
+          EOF
+          fi
           sudo chmod +x /usr/local/bin/docker-compose
 
-      - name: Verify Docker Compose v1 installation
+      - name: Verify Docker Compose installation
         run: docker-compose --version
 
       - name: Set up QEMU for cross-platform containers

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -63,23 +63,31 @@ jobs:
             platform: linux/arm64
             experimental: true
     steps:
+      - name: Skip experimental matrix on push and pull_request
+        if: ${{ matrix.experimental && github.event_name != 'workflow_dispatch' }}
+        run: echo "Experimental E2E matrix is skipped on ${GITHUB_EVENT_NAME}; run workflow_dispatch to execute it."
+
       - name: Uninstall Docker Compose v2
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: sudo rm -f /usr/local/bin/docker-compose
 
       - name: Install Docker Compose v1
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           DOCKER_COMPOSE_VERSION=1.29.2
           sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
 
       - name: Verify Docker Compose v1 installation
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: docker-compose --version
 
       - name: Set up QEMU for cross-platform containers
-        if: matrix.platform != 'linux/amd64'
+        if: ${{ matrix.platform != 'linux/amd64' && (!matrix.experimental || github.event_name == 'workflow_dispatch') }}
         uses: docker/setup-qemu-action@v3
 
       - name: Check Docker environment
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           sudo systemctl status docker || true
           docker --version
@@ -92,24 +100,29 @@ jobs:
           sudo lsof -i :7091 || true
 
       - name: Check out code
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v3
 
       - name: Clone skywalking e2e repository
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: git clone https://github.com/apache/skywalking-infra-e2e.git skywalking-infra-e2e
 
       - name: Set up Go 1.18
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
         id: go
 
       - name: Build e2e framework (use skywalking-infra-e2e v1.3.0)
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           cd skywalking-infra-e2e
           git checkout 1485ae03f0ad90496ad7626a5ae4a6a73a1f6296
           make linux
 
       - name: Add script directory to PATH
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           cd skywalking-infra-e2e/bin/linux
           echo "export PATH=$PATH:$(pwd)" >> $GITHUB_PATH
@@ -117,12 +130,14 @@ jobs:
           cp e2e /usr/local/bin
 
       - name: Set up JDK ${{ matrix.build_jdk }} for build
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.build_jdk }}
 
       - name: Set E2E environment matrix
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           echo "=========================================="
           echo "E2E Test Configuration:"
@@ -140,11 +155,13 @@ jobs:
           echo "E2E_DOCKER_PLATFORM=${{ matrix.platform }}" >> $GITHUB_ENV
 
       - name: Prepare e2e tests
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           cd e2e-test/scripts
           sh prepare-test.sh
 
       - name: Check docker resources after prepare-test.sh
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           echo "===== After prepare-test.sh: Docker containers status ====="
           docker ps -a
@@ -152,6 +169,7 @@ jobs:
           docker images
 
       - name: Run e2e tests
+        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         id: e2e_test
         run: |
           set -euo pipefail
@@ -161,7 +179,7 @@ jobs:
           exit $TEST_EXIT_CODE
 
       - name: Collect debug logs
-        if: always()
+        if: ${{ always() && (!matrix.experimental || github.event_name == 'workflow_dispatch') }}
         run: |
           echo "===== Docker version info ====="
           docker --version
@@ -196,7 +214,7 @@ jobs:
           sudo lsof -i -P -n | grep LISTEN || true
 
       - name: Upload debug logs
-        if: always()
+        if: ${{ always() && (!matrix.experimental || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-artifact@v4
         with:
           name: e2e-debug-logs-${{ matrix.name }}

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -55,9 +55,9 @@ jobs:
             platform: linux/amd64
             experimental: true
           - name: jdk17-mysql80-arm64
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             build_jdk: 17
-            runtime_jdk_image: eclipse-temurin:17-jdk-alpine
+            runtime_jdk_image: bellsoft/liberica-openjdk-alpine:17
             mysql_image: mysql:8.0
             mysql_connector_version: 8.0.33
             platform: linux/arm64
@@ -76,7 +76,7 @@ jobs:
         run: docker-compose --version
 
       - name: Set up QEMU for cross-platform containers
-        if: matrix.platform != 'linux/amd64'
+        if: matrix.platform != 'linux/amd64' && matrix.os == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v3
 
       - name: Check Docker environment

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -6,6 +6,7 @@ jobs:
   run_e2e:
     name: E2E ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     env:
       DEBIAN_FRONTEND: noninteractive
     strategy:
@@ -20,6 +21,23 @@ jobs:
             mysql_image: mysql:5.7
             mysql_connector_version: 8.0.31
             platform: linux/amd64
+            experimental: false
+          - name: jdk11-mysql57-amd64
+            os: ubuntu-latest
+            build_jdk: 11
+            runtime_jdk_image: eclipse-temurin:11-jdk-alpine
+            mysql_image: mysql:5.7
+            mysql_connector_version: 8.0.31
+            platform: linux/amd64
+            experimental: false
+          - name: jdk17-mysql57-amd64
+            os: ubuntu-latest
+            build_jdk: 17
+            runtime_jdk_image: eclipse-temurin:17-jdk-alpine
+            mysql_image: mysql:5.7
+            mysql_connector_version: 8.0.31
+            platform: linux/amd64
+            experimental: false
           - name: jdk11-mysql80-amd64
             os: ubuntu-latest
             build_jdk: 11
@@ -27,6 +45,7 @@ jobs:
             mysql_image: mysql:8.0
             mysql_connector_version: 8.0.33
             platform: linux/amd64
+            experimental: true
           - name: jdk17-mysql80-amd64
             os: ubuntu-latest
             build_jdk: 17
@@ -34,6 +53,7 @@ jobs:
             mysql_image: mysql:8.0
             mysql_connector_version: 8.0.33
             platform: linux/amd64
+            experimental: true
           - name: jdk17-mysql80-arm64
             os: ubuntu-latest
             build_jdk: 17
@@ -41,6 +61,7 @@ jobs:
             mysql_image: mysql:8.0
             mysql_connector_version: 8.0.33
             platform: linux/arm64
+            experimental: true
     steps:
       - name: Uninstall Docker Compose v2
         run: sudo rm -f /usr/local/bin/docker-compose
@@ -111,6 +132,7 @@ jobs:
           echo "MySQL Image: ${{ matrix.mysql_image }}"
           echo "MySQL Connector Version: ${{ matrix.mysql_connector_version }}"
           echo "Docker Platform: ${{ matrix.platform }}"
+          echo "Experimental: ${{ matrix.experimental }}"
           echo "=========================================="
           echo "E2E_JDK_BASE_IMAGE=${{ matrix.runtime_jdk_image }}" >> $GITHUB_ENV
           echo "E2E_MYSQL_IMAGE=${{ matrix.mysql_image }}" >> $GITHUB_ENV

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -63,31 +63,23 @@ jobs:
             platform: linux/arm64
             experimental: true
     steps:
-      - name: Skip experimental matrix on push and pull_request
-        if: ${{ matrix.experimental && github.event_name != 'workflow_dispatch' }}
-        run: echo "Experimental E2E matrix is skipped on ${GITHUB_EVENT_NAME}; run workflow_dispatch to execute it."
-
       - name: Uninstall Docker Compose v2
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: sudo rm -f /usr/local/bin/docker-compose
 
       - name: Install Docker Compose v1
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           DOCKER_COMPOSE_VERSION=1.29.2
           sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
 
       - name: Verify Docker Compose v1 installation
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: docker-compose --version
 
       - name: Set up QEMU for cross-platform containers
-        if: ${{ matrix.platform != 'linux/amd64' && (!matrix.experimental || github.event_name == 'workflow_dispatch') }}
+        if: matrix.platform != 'linux/amd64'
         uses: docker/setup-qemu-action@v3
 
       - name: Check Docker environment
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           sudo systemctl status docker || true
           docker --version
@@ -100,29 +92,24 @@ jobs:
           sudo lsof -i :7091 || true
 
       - name: Check out code
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v3
 
       - name: Clone skywalking e2e repository
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: git clone https://github.com/apache/skywalking-infra-e2e.git skywalking-infra-e2e
 
       - name: Set up Go 1.18
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
         id: go
 
       - name: Build e2e framework (use skywalking-infra-e2e v1.3.0)
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           cd skywalking-infra-e2e
           git checkout 1485ae03f0ad90496ad7626a5ae4a6a73a1f6296
           make linux
 
       - name: Add script directory to PATH
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           cd skywalking-infra-e2e/bin/linux
           echo "export PATH=$PATH:$(pwd)" >> $GITHUB_PATH
@@ -130,14 +117,12 @@ jobs:
           cp e2e /usr/local/bin
 
       - name: Set up JDK ${{ matrix.build_jdk }} for build
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.build_jdk }}
 
       - name: Set E2E environment matrix
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           echo "=========================================="
           echo "E2E Test Configuration:"
@@ -155,13 +140,11 @@ jobs:
           echo "E2E_DOCKER_PLATFORM=${{ matrix.platform }}" >> $GITHUB_ENV
 
       - name: Prepare e2e tests
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           cd e2e-test/scripts
           sh prepare-test.sh
 
       - name: Check docker resources after prepare-test.sh
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         run: |
           echo "===== After prepare-test.sh: Docker containers status ====="
           docker ps -a
@@ -169,7 +152,6 @@ jobs:
           docker images
 
       - name: Run e2e tests
-        if: ${{ !matrix.experimental || github.event_name == 'workflow_dispatch' }}
         id: e2e_test
         run: |
           set -euo pipefail
@@ -179,7 +161,7 @@ jobs:
           exit $TEST_EXIT_CODE
 
       - name: Collect debug logs
-        if: ${{ always() && (!matrix.experimental || github.event_name == 'workflow_dispatch') }}
+        if: always()
         run: |
           echo "===== Docker version info ====="
           docker --version
@@ -214,7 +196,7 @@ jobs:
           sudo lsof -i -P -n | grep LISTEN || true
 
       - name: Upload debug logs
-        if: ${{ always() && (!matrix.experimental || github.event_name == 'workflow_dispatch') }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-debug-logs-${{ matrix.name }}

--- a/at-sample/at-api/pom.xml
+++ b/at-sample/at-api/pom.xml
@@ -24,6 +24,7 @@
     <version>2.3.0</version>
 
     <properties>
+        <mysql.connector.version>8.0.28</mysql.connector.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -71,7 +72,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
     </dependencies>
 

--- a/at-sample/at-api/seata-e2e.yaml
+++ b/at-sample/at-api/seata-e2e.yaml
@@ -72,5 +72,5 @@ e2e:
   # cases to verify
   cases:
     - name: normal test success
-      invoke: 'docker exec test cat result.yaml'
+      invoke: 'docker exec test cat /seata-e2e/result.yaml'
       verify: './e2e-files/rollback.yaml'

--- a/at-sample/dubbo-samples-seata/dubbo-samples-seata-account/pom.xml
+++ b/at-sample/dubbo-samples-seata/dubbo-samples-seata-account/pom.xml
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql.connector.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/at-sample/dubbo-samples-seata/dubbo-samples-seata-order/pom.xml
+++ b/at-sample/dubbo-samples-seata/dubbo-samples-seata-order/pom.xml
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql.connector.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/at-sample/dubbo-samples-seata/dubbo-samples-seata-stock/pom.xml
+++ b/at-sample/dubbo-samples-seata/dubbo-samples-seata-stock/pom.xml
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql.connector.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/at-sample/dubbo-samples-seata/pom.xml
+++ b/at-sample/dubbo-samples-seata/pom.xml
@@ -25,6 +25,7 @@
     <name>dubbo-samples-seata</name>
     <description>dubbo samples seata</description>
     <properties>
+        <mysql.connector.version>8.0.31</mysql.connector.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/at-sample/spring-dubbo-seata/pom.xml
+++ b/at-sample/spring-dubbo-seata/pom.xml
@@ -36,6 +36,7 @@
     </modules>
 
     <properties>
+        <mysql.connector.version>8.0.28</mysql.connector.version>
         <java.version>8</java.version>
     </properties>
 </project>

--- a/at-sample/spring-dubbo-seata/seata-e2e.yaml
+++ b/at-sample/spring-dubbo-seata/seata-e2e.yaml
@@ -148,5 +148,5 @@ e2e:
   # cases to verify
   cases:
     - name: normal test success
-      invoke: 'docker exec test cat result.yaml'
+      invoke: 'docker exec test cat /seata-e2e/result.yaml'
       verify: './e2e-files/success.yaml'

--- a/at-sample/spring-dubbo-seata/spring-dubbo-seata-account/pom.xml
+++ b/at-sample/spring-dubbo-seata/spring-dubbo-seata-account/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/at-sample/spring-dubbo-seata/spring-dubbo-seata-business/pom.xml
+++ b/at-sample/spring-dubbo-seata/spring-dubbo-seata-business/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/at-sample/spring-dubbo-seata/spring-dubbo-seata-order/pom.xml
+++ b/at-sample/spring-dubbo-seata/spring-dubbo-seata-order/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/at-sample/spring-dubbo-seata/spring-dubbo-seata-storage/pom.xml
+++ b/at-sample/spring-dubbo-seata/spring-dubbo-seata-storage/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/at-sample/spring-seata/pom.xml
+++ b/at-sample/spring-seata/pom.xml
@@ -25,6 +25,7 @@
     <version>2.3.0</version>
 
     <properties>
+        <mysql.connector.version>8.0.28</mysql.connector.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -83,7 +84,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
     </dependencies>
 

--- a/at-sample/spring-seata/seata-e2e.yaml
+++ b/at-sample/spring-seata/seata-e2e.yaml
@@ -72,5 +72,5 @@ e2e:
   # cases to verify
   cases:
     - name: normal test success
-      invoke: 'docker exec test cat result.yaml'
+      invoke: 'docker exec test cat /seata-e2e/result.yaml'
       verify: './e2e-files/success.yaml'

--- a/at-sample/springboot-dubbo-seata/pom.xml
+++ b/at-sample/springboot-dubbo-seata/pom.xml
@@ -40,6 +40,7 @@
     </modules>
 
     <properties>
+        <mysql.connector.version>8.0.28</mysql.connector.version>
         <java.version>8</java.version>
     </properties>
 </project>

--- a/at-sample/springboot-dubbo-seata/springboot-dubbo-seata-account/pom.xml
+++ b/at-sample/springboot-dubbo-seata/springboot-dubbo-seata-account/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/at-sample/springboot-dubbo-seata/springboot-dubbo-seata-order/pom.xml
+++ b/at-sample/springboot-dubbo-seata/springboot-dubbo-seata-order/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/at-sample/springboot-dubbo-seata/springboot-dubbo-seata-storage/pom.xml
+++ b/at-sample/springboot-dubbo-seata/springboot-dubbo-seata-storage/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/at-sample/springboot-mybatis-seata/pom.xml
+++ b/at-sample/springboot-mybatis-seata/pom.xml
@@ -30,6 +30,7 @@
 	<name>springboot-mybatis-seata</name>
 	<description>springboot-mybatis-seata</description>
 	<properties>
+		<mysql.connector.version>8.0.28</mysql.connector.version>
 		<java.version>8</java.version>
 	</properties>
 	<dependencies>
@@ -63,7 +64,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.28</version>
+			<version>${mysql.connector.version}</version>
 		</dependency>
 
 		<dependency>

--- a/at-sample/springboot-mybatis-seata/seata-e2e.yaml
+++ b/at-sample/springboot-mybatis-seata/seata-e2e.yaml
@@ -72,5 +72,5 @@ e2e:
   # cases to verify
   cases:
     - name: normal test rollback
-      invoke: 'docker exec test cat result.yaml'
+      invoke: 'docker exec test cat /seata-e2e/result.yaml'
       verify: './e2e-files/success.yaml'

--- a/at-sample/springboot-seata/pom.xml
+++ b/at-sample/springboot-seata/pom.xml
@@ -30,6 +30,7 @@
 	<name>springboot-seata</name>
 	<description>springboot-seata</description>
 	<properties>
+		<mysql.connector.version>8.0.28</mysql.connector.version>
 		<java.version>8</java.version>
 	</properties>
 	<dependencies>
@@ -63,7 +64,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.28</version>
+			<version>${mysql.connector.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/at-sample/springboot-seata/seata-e2e.yaml
+++ b/at-sample/springboot-seata/seata-e2e.yaml
@@ -72,5 +72,5 @@ e2e:
   # cases to verify
   cases:
     - name: normal test rollback
-      invoke: 'docker exec test cat result.yaml'
+      invoke: 'docker exec test cat /seata-e2e/result.yaml'
       verify: './e2e-files/success.yaml'

--- a/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/builder/ImageBuilder.java
+++ b/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/builder/ImageBuilder.java
@@ -101,6 +101,13 @@ public class ImageBuilder {
         } else {
             builder.command("mvn", "clean", "package");
         }
+        String mysqlConnectorVersion = ConfigConstants.getEnvValue(ConfigConstants.ENV_MYSQL_CONNECTOR_VERSION);
+        if (mysqlConnectorVersion != null) {
+            List<String> command = new ArrayList<>(builder.command());
+            command.add("-Dmysql.connector.version=" + mysqlConnectorVersion);
+            builder.command(command);
+            LOGGER.info("Packaging Maven module with MySQL connector version: {}", mysqlConnectorVersion);
+        }
         Process process = builder.start();
         printProcessLog(LOGGER, process);
         int exitCode = process.waitFor();
@@ -149,7 +156,13 @@ public class ImageBuilder {
             String moduleComposeDir = new File(composeDir, e2EConfig.getScene_name() + "-" + module.getName()).getAbsolutePath();
             ProcessBuilder builder = new ProcessBuilder();
             builder.directory(new File(moduleComposeDir));
-            builder.command("docker", "build", "-t", imageTag, ".");
+            String dockerPlatform = ConfigConstants.getEnvValue(ConfigConstants.ENV_DOCKER_PLATFORM);
+            if (dockerPlatform == null) {
+                builder.command("docker", "build", "-t", imageTag, ".");
+            } else {
+                LOGGER.info("Building Docker image for module {} with platform: {}", module.getName(), dockerPlatform);
+                builder.command("docker", "build", "--platform", dockerPlatform, "-t", imageTag, ".");
+            }
             Process process = builder.start();
             printProcessLog(LOGGER, process);
             int exitCode = process.waitFor();
@@ -162,7 +175,7 @@ public class ImageBuilder {
                         module.getName(), exitCode, stdout, stderr));
                 continue;
             }
-            // 校验镜像是否存在且可用
+            // Verify that the image exists and is available.
             ProcessBuilder inspectBuilder = new ProcessBuilder("docker", "image", "inspect", imageTag);
             Process inspectProcess = inspectBuilder.start();
             printProcessLog(LOGGER, inspectProcess);

--- a/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/config/ConfigConstants.java
+++ b/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/config/ConfigConstants.java
@@ -37,11 +37,14 @@ public class ConfigConstants {
     // JDK base image configuration
     public static final String DEFAULT_BASE_IMAGE = "openjdk:8-jdk-alpine";
     public static final String ENV_JDK_BASE_IMAGE = "E2E_JDK_BASE_IMAGE";
+    public static final String ENV_MYSQL_IMAGE = "E2E_MYSQL_IMAGE";
+    public static final String ENV_MYSQL_CONNECTOR_VERSION = "E2E_MYSQL_CONNECTOR_VERSION";
+    public static final String ENV_DOCKER_PLATFORM = "E2E_DOCKER_PLATFORM";
     
     // Predefined JDK image mapping
     private static final Map<String, String> JDK_IMAGE_MAP = new HashMap<String, String>() {{
         put("8", "eclipse-temurin:8-jdk-alpine");
-        put("11", "eclipse-temurin:8-jdk-alpine");
+        put("11", "eclipse-temurin:11-jdk-alpine");
         put("17", "eclipse-temurin:17-jdk-alpine");
         put("21", "eclipse-temurin:21-jdk-alpine");
         // Support for different distributions
@@ -76,5 +79,13 @@ public class ConfigConstants {
             System.out.println("[E2E] Using default base image: " + DEFAULT_BASE_IMAGE);
         }
         return DEFAULT_BASE_IMAGE;
+    }
+
+    public static String getEnvValue(String envName) {
+        String envValue = System.getenv(envName);
+        if (envValue == null || envValue.trim().isEmpty()) {
+            return null;
+        }
+        return envValue.trim();
     }
 }

--- a/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/generator/DockerComposeGenerator.java
+++ b/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/generator/DockerComposeGenerator.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,26 +93,40 @@ public class DockerComposeGenerator {
         String dockerPlatform = ConfigConstants.getEnvValue(ConfigConstants.ENV_DOCKER_PLATFORM);
         String mysqlImage = ConfigConstants.getEnvValue(ConfigConstants.ENV_MYSQL_IMAGE);
 
-        List<List<Module>> moduleGroups = Arrays.asList(modules.getConsumers(), modules.getProviders(), modules.getInfrastructures());
-        for (List<Module> moduleGroup : moduleGroups) {
-            if (moduleGroup == null) {
+        applyApplicationPlatformOverride(modules.getConsumers(), dockerPlatform);
+        applyApplicationPlatformOverride(modules.getProviders(), dockerPlatform);
+        applyInfrastructureOverrides(modules.getInfrastructures(), dockerPlatform, mysqlImage);
+    }
+
+    private void applyApplicationPlatformOverride(List<Module> modules, String dockerPlatform) {
+        if (modules == null || dockerPlatform == null) {
+            return;
+        }
+        for (Module module : modules) {
+            if (module.getDocker_service() != null) {
+                module.getDocker_service().setPlatform(dockerPlatform);
+            }
+        }
+    }
+
+    private void applyInfrastructureOverrides(List<Module> modules, String dockerPlatform, String mysqlImage) {
+        if (modules == null) {
+            return;
+        }
+        for (Module module : modules) {
+            if (module.getDocker_service() == null || !"mysql".equals(module.getName())) {
                 continue;
             }
-            for (Module module : moduleGroup) {
-                if (module.getDocker_service() == null) {
-                    continue;
-                }
-                if (dockerPlatform != null) {
-                    module.getDocker_service().setPlatform(dockerPlatform);
-                }
-                if (mysqlImage != null && "mysql".equals(module.getName())) {
-                    String originalImage = module.getDocker_service().getImage();
-                    module.getDocker_service().setImage(mysqlImage);
-                    LOGGER.info("[E2E] Override MySQL image: {} -> {}", originalImage, mysqlImage);
-                    if (isMySQL8Image(mysqlImage)) {
-                        module.getDocker_service().setCommand(MYSQL_NATIVE_PASSWORD_COMMAND);
-                        LOGGER.info("[E2E] Use MySQL native password authentication for image: {}", mysqlImage);
-                    }
+            if (dockerPlatform != null) {
+                module.getDocker_service().setPlatform(dockerPlatform);
+            }
+            if (mysqlImage != null) {
+                String originalImage = module.getDocker_service().getImage();
+                module.getDocker_service().setImage(mysqlImage);
+                LOGGER.info("[E2E] Override MySQL image: {} -> {}", originalImage, mysqlImage);
+                if (isMySQL8Image(mysqlImage)) {
+                    module.getDocker_service().setCommand(MYSQL_NATIVE_PASSWORD_COMMAND);
+                    LOGGER.info("[E2E] Use MySQL native password authentication for image: {}", mysqlImage);
                 }
             }
         }

--- a/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/generator/DockerComposeGenerator.java
+++ b/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/generator/DockerComposeGenerator.java
@@ -19,7 +19,9 @@ package org.apache.seata.generator;
 import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
+import org.apache.seata.config.ConfigConstants;
 import org.apache.seata.model.E2EConfig;
+import org.apache.seata.model.Module;
 import org.apache.seata.model.Modules;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +30,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.seata.config.ConfigConstants.COMPOSE_FILE;
@@ -57,6 +61,7 @@ public class DockerComposeGenerator {
     public void generateDockerComposeFile(E2EConfig e2EConfig, File file) {
         try {
             Modules modules = e2EConfig.getModules();
+            applyEnvironmentOverrides(modules);
             Map<String, Object> map = new HashMap<>();
             map.put("modules", modules);
             
@@ -81,6 +86,31 @@ public class DockerComposeGenerator {
         } catch (TemplateException | IOException e) {
             LOGGER.error(String.format("generate docker-compose file for %s fail", e2EConfig.getScene_name()
                     + "-" + e2EConfig.getScene_name()), e);
+        }
+    }
+
+    private void applyEnvironmentOverrides(Modules modules) {
+        String dockerPlatform = ConfigConstants.getEnvValue(ConfigConstants.ENV_DOCKER_PLATFORM);
+        String mysqlImage = ConfigConstants.getEnvValue(ConfigConstants.ENV_MYSQL_IMAGE);
+
+        List<List<Module>> moduleGroups = Arrays.asList(modules.getConsumers(), modules.getProviders(), modules.getInfrastructures());
+        for (List<Module> moduleGroup : moduleGroups) {
+            if (moduleGroup == null) {
+                continue;
+            }
+            for (Module module : moduleGroup) {
+                if (module.getDocker_service() == null) {
+                    continue;
+                }
+                if (dockerPlatform != null) {
+                    module.getDocker_service().setPlatform(dockerPlatform);
+                }
+                if (mysqlImage != null && "mysql".equals(module.getName())) {
+                    String originalImage = module.getDocker_service().getImage();
+                    module.getDocker_service().setImage(mysqlImage);
+                    LOGGER.info("[E2E] Override MySQL image: {} -> {}", originalImage, mysqlImage);
+                }
+            }
         }
     }
 }

--- a/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/generator/DockerComposeGenerator.java
+++ b/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/generator/DockerComposeGenerator.java
@@ -42,6 +42,7 @@ import static org.apache.seata.config.ConfigConstants.COMPOSE_FILE;
  */
 public class DockerComposeGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(DockerComposeGenerator.class);
+    private static final String MYSQL_NATIVE_PASSWORD_COMMAND = "--default-authentication-plugin=mysql_native_password";
     private final Configuration cfg;
 
     public DockerComposeGenerator() {
@@ -109,8 +110,16 @@ public class DockerComposeGenerator {
                     String originalImage = module.getDocker_service().getImage();
                     module.getDocker_service().setImage(mysqlImage);
                     LOGGER.info("[E2E] Override MySQL image: {} -> {}", originalImage, mysqlImage);
+                    if (isMySQL8Image(mysqlImage)) {
+                        module.getDocker_service().setCommand(MYSQL_NATIVE_PASSWORD_COMMAND);
+                        LOGGER.info("[E2E] Use MySQL native password authentication for image: {}", mysqlImage);
+                    }
                 }
             }
         }
+    }
+
+    private boolean isMySQL8Image(String image) {
+        return image.startsWith("mysql:8");
     }
 }

--- a/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/model/DockerService.java
+++ b/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/model/DockerService.java
@@ -35,6 +35,15 @@ public class DockerService {
     private Map<String, String> environment;
     private List<String> volumes;
     private String container_name;
+    private String platform;
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public void setPlatform(String platform) {
+        this.platform = platform;
+    }
 
     public String getContainer_name() {
         return container_name;

--- a/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/model/DockerService.java
+++ b/e2e-test/e2e-test-builder/src/main/java/org/apache/seata/model/DockerService.java
@@ -36,6 +36,15 @@ public class DockerService {
     private List<String> volumes;
     private String container_name;
     private String platform;
+    private String command;
+
+    public String getCommand() {
+        return command;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
 
     public String getPlatform() {
         return platform;

--- a/e2e-test/e2e-test-builder/src/main/resources/template/application-dockerFile.ftl
+++ b/e2e-test/e2e-test-builder/src/main/resources/template/application-dockerFile.ftl
@@ -36,7 +36,16 @@ echo "Hostname: $(hostname)"\n\
 echo "Start Time: $(date)"\n\
 echo "=========================================="\n\
 echo "Starting Application..."\n\
-exec java -jar app.jar\n' > /startup.sh && \
+JAVA_VERSION_STRING=$(java -version 2>&1 | head -n 1 | cut -d \\" -f 2)\n\
+JAVA_VERSION=$(echo "$JAVA_VERSION_STRING" | cut -d . -f 1)\n\
+if [ "$JAVA_VERSION" = "1" ]; then\n\
+  JAVA_VERSION=$(echo "$JAVA_VERSION_STRING" | cut -d . -f 2)\n\
+fi\n\
+JAVA_OPTS="$JAVA_OPTS"\n\
+if [ "$JAVA_VERSION" -ge 9 ] 2>/dev/null; then\n\
+  JAVA_OPTS="$JAVA_OPTS --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED"\n\
+fi\n\
+exec java $JAVA_OPTS -jar app.jar\n' > /startup.sh && \
     chmod +x /startup.sh
 
 ENTRYPOINT ["/startup.sh"]

--- a/e2e-test/e2e-test-builder/src/main/resources/template/application-dockerFile.ftl
+++ b/e2e-test/e2e-test-builder/src/main/resources/template/application-dockerFile.ftl
@@ -16,8 +16,11 @@
 -->
 
 FROM ${baseImage!"eclipse-temurin:8-jdk-alpine"}
-RUN apk --no-cache add curl bash
-COPY ${sourceJar} /app.jar
+RUN apk --no-cache add curl bash && \
+    mkdir -p /seata-e2e && \
+    chmod 777 /seata-e2e
+WORKDIR /seata-e2e
+COPY ${sourceJar} app.jar
 
 # Create startup script with JDK version logging
 RUN printf '#!/bin/bash\n\
@@ -33,7 +36,7 @@ echo "Hostname: $(hostname)"\n\
 echo "Start Time: $(date)"\n\
 echo "=========================================="\n\
 echo "Starting Application..."\n\
-exec java -jar /app.jar\n' > /startup.sh && \
+exec java -jar app.jar\n' > /startup.sh && \
     chmod +x /startup.sh
 
 ENTRYPOINT ["/startup.sh"]

--- a/e2e-test/e2e-test-builder/src/main/resources/template/dockercompose.ftl
+++ b/e2e-test/e2e-test-builder/src/main/resources/template/dockercompose.ftl
@@ -26,6 +26,9 @@ services:
     <#if service.docker_service.platform?has_content>
         platform: ${service.docker_service.platform}
     </#if>
+    <#if service.docker_service.command?has_content>
+        command: ${service.docker_service.command}
+    </#if>
     <#if service.docker_service.networks?has_content>
         networks: ${service.docker_service.networks}
     </#if>
@@ -86,6 +89,9 @@ services:
     <#if service.docker_service.platform?has_content>
         platform: ${service.docker_service.platform}
     </#if>
+    <#if service.docker_service.command?has_content>
+        command: ${service.docker_service.command}
+    </#if>
     <#if service.docker_service.networks?has_content>
         networks: ${service.docker_service.networks}
     </#if>
@@ -145,6 +151,9 @@ services:
     </#if>
     <#if service.docker_service.platform?has_content>
         platform: ${service.docker_service.platform}
+    </#if>
+    <#if service.docker_service.command?has_content>
+        command: ${service.docker_service.command}
     </#if>
     <#if service.docker_service.networks?has_content>
         networks: ${service.docker_service.networks}

--- a/e2e-test/e2e-test-builder/src/main/resources/template/dockercompose.ftl
+++ b/e2e-test/e2e-test-builder/src/main/resources/template/dockercompose.ftl
@@ -23,6 +23,9 @@ services:
     <#if service.docker_service.image?has_content>
         image: ${service.docker_service.image}
     </#if>
+    <#if service.docker_service.platform?has_content>
+        platform: ${service.docker_service.platform}
+    </#if>
     <#if service.docker_service.networks?has_content>
         networks: ${service.docker_service.networks}
     </#if>
@@ -80,6 +83,9 @@ services:
     <#if service.docker_service.image?has_content>
         image: ${service.docker_service.image}
     </#if>
+    <#if service.docker_service.platform?has_content>
+        platform: ${service.docker_service.platform}
+    </#if>
     <#if service.docker_service.networks?has_content>
         networks: ${service.docker_service.networks}
     </#if>
@@ -136,6 +142,9 @@ services:
     ${service.name}:
     <#if service.docker_service.image?has_content>
         image: ${service.docker_service.image}
+    </#if>
+    <#if service.docker_service.platform?has_content>
+        platform: ${service.docker_service.platform}
     </#if>
     <#if service.docker_service.networks?has_content>
         networks: ${service.docker_service.networks}

--- a/e2e-test/e2e-test-builder/src/main/resources/template/jar-dockerFile.ftl
+++ b/e2e-test/e2e-test-builder/src/main/resources/template/jar-dockerFile.ftl
@@ -16,8 +16,11 @@
 -->
 
 FROM ${baseImage!"eclipse-temurin:8-jdk-alpine"}
-RUN apk --no-cache add bash
-COPY ${sourceJar} /app.jar
+RUN apk --no-cache add bash && \
+    mkdir -p /seata-e2e && \
+    chmod 777 /seata-e2e
+WORKDIR /seata-e2e
+COPY ${sourceJar} app.jar
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/e2e-test/scripts/prepare-test.sh
+++ b/e2e-test/scripts/prepare-test.sh
@@ -30,6 +30,9 @@ if [ -n "$E2E_JDK_BASE_IMAGE" ]; then
 else
   echo "  - Docker Base Image: openjdk:8-jdk-alpine (default)"
 fi
+echo "  - MySQL Image: ${E2E_MYSQL_IMAGE:-default from seata-e2e.yaml}"
+echo "  - MySQL Connector Version: ${E2E_MYSQL_CONNECTOR_VERSION:-default from pom.xml}"
+echo "  - Docker Platform: ${E2E_DOCKER_PLATFORM:-default runner platform}"
 echo "=========================================="
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/e2e-test/scripts/test-run.sh
+++ b/e2e-test/scripts/test-run.sh
@@ -30,6 +30,9 @@ if [ -n "$E2E_JDK_BASE_IMAGE" ]; then
 else
   echo "  - Docker Runtime JDK: openjdk:8-jdk-alpine (default)"
 fi
+echo "  - MySQL Image: ${E2E_MYSQL_IMAGE:-default from seata-e2e.yaml}"
+echo "  - MySQL Connector Version: ${E2E_MYSQL_CONNECTOR_VERSION:-default from pom.xml}"
+echo "  - Docker Platform: ${E2E_DOCKER_PLATFORM:-default runner platform}"
 echo "=========================================="
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/saga-annotation-sample/seata-e2e.yaml
+++ b/saga-annotation-sample/seata-e2e.yaml
@@ -48,5 +48,5 @@ e2e:
   # cases to verify
   cases:
     - name: normal test success
-      invoke: 'docker exec test cat result.yaml'
+      invoke: 'docker exec test cat /seata-e2e/result.yaml'
       verify: './e2e-files/rollback.yaml'

--- a/saga-sample/spring-seata-dubbo-saga/seata-e2e.yaml
+++ b/saga-sample/spring-seata-dubbo-saga/seata-e2e.yaml
@@ -91,8 +91,8 @@ e2e:
   # cases to verify
   cases:
     - name: normal test commit
-      invoke: 'docker exec test cat commit.yaml'
+      invoke: 'docker exec test cat /seata-e2e/commit.yaml'
       verify: './e2e-files/commit.yaml'
     - name: normal test rollback
-      invoke: 'docker exec test cat rollback.yaml'
+      invoke: 'docker exec test cat /seata-e2e/rollback.yaml'
       verify: './e2e-files/rollback.yaml'

--- a/saga-sample/spring-seata-saga/seata-e2e.yaml
+++ b/saga-sample/spring-seata-saga/seata-e2e.yaml
@@ -54,8 +54,8 @@ e2e:
   # cases to verify
   cases:
     - name: normal test rollback
-      invoke: 'docker exec test cat rollback.yaml'
+      invoke: 'docker exec test cat /seata-e2e/rollback.yaml'
       verify: './e2e-files/rollback.yaml'
     - name: normal test commit
-      invoke: 'docker exec test cat commit.yaml'
+      invoke: 'docker exec test cat /seata-e2e/commit.yaml'
       verify: './e2e-files/commit.yaml'

--- a/tcc-sample/spring-dubbo-seata-tcc/seata-e2e.yaml
+++ b/tcc-sample/spring-dubbo-seata-tcc/seata-e2e.yaml
@@ -91,8 +91,8 @@ e2e:
   # cases to verify
   cases:
     - name: normal test rollback
-      invoke: 'docker exec test cat rollback.yaml'
+      invoke: 'docker exec test cat /seata-e2e/rollback.yaml'
       verify: './e2e-files/rollback.yaml'
     - name: normal test commit
-      invoke: 'docker exec test cat commit.yaml'
+      invoke: 'docker exec test cat /seata-e2e/commit.yaml'
       verify: './e2e-files/commit.yaml'

--- a/tcc-sample/springboot-sofarpc-seata-tcc/seata-e2e.yaml
+++ b/tcc-sample/springboot-sofarpc-seata-tcc/seata-e2e.yaml
@@ -53,8 +53,8 @@ e2e:
   # cases to verify
   cases:
     - name: normal test rollback
-      invoke: 'docker exec test cat rollback.yaml'
+      invoke: 'docker exec test cat /seata-e2e/rollback.yaml'
       verify: './e2e-files/rollback.yaml'
     - name: normal test commit
-      invoke: 'docker exec test cat commit.yaml'
+      invoke: 'docker exec test cat /seata-e2e/commit.yaml'
       verify: './e2e-files/commit.yaml'

--- a/xa-sample/springboot-feign-seata-xa/pom.xml
+++ b/xa-sample/springboot-feign-seata-xa/pom.xml
@@ -39,6 +39,7 @@
     </modules>
 
     <properties>
+        <mysql.connector.version>8.0.28</mysql.connector.version>
         <java.version>8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/xa-sample/springboot-feign-seata-xa/springboot-feign-seata-account/pom.xml
+++ b/xa-sample/springboot-feign-seata-xa/springboot-feign-seata-account/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.seata</groupId>

--- a/xa-sample/springboot-feign-seata-xa/springboot-feign-seata-business/pom.xml
+++ b/xa-sample/springboot-feign-seata-xa/springboot-feign-seata-business/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/xa-sample/springboot-feign-seata-xa/springboot-feign-seata-order/pom.xml
+++ b/xa-sample/springboot-feign-seata-xa/springboot-feign-seata-order/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/xa-sample/springboot-feign-seata-xa/springboot-feign-seata-storage/pom.xml
+++ b/xa-sample/springboot-feign-seata-xa/springboot-feign-seata-storage/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>${mysql.connector.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Introduce an E2E environment compatibility matrix for Seata samples.

This PR adds CI support for running the existing E2E test suite against different environment combinations, including:

- Different build/runtime JDK versions
- Different MySQL images
- Different MySQL connector versions
- Different system architectures, including `linux/amd64` and `linux/arm64`

Main changes include:

- Add a GitHub Actions E2E matrix with 6 representative combinations.
- Allow CI to inject the runtime JDK Docker image through `E2E_JDK_BASE_IMAGE`.
- Allow CI to override the MySQL Docker image through `E2E_MYSQL_IMAGE`.
- Extract MySQL connector versions into Maven properties and allow CI override through `E2E_MYSQL_CONNECTOR_VERSION`.
- Allow Docker build/compose platform override through `E2E_DOCKER_PLATFORM`.
- Fix the JDK 11 runtime image mapping.
- Add MySQL 8 native password compatibility for E2E containers.
- Support native ARM runners by using Docker Compose v2 through a `docker-compose` wrapper.
- Stabilize E2E result file paths by using a fixed `/seata-e2e` working directory and absolute result-file paths.
- Add required JDK module `--add-opens` options for old Spring Boot / Netty based samples running on JDK 17.

### Ⅱ. Does this pull request fix one issue?

fixes apache/incubator-seata#7178

### Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR updates the E2E test infrastructure itself rather than adding new business logic.

The coverage is provided by the GitHub Actions E2E matrix, which reuses the existing Seata samples and E2E cases with different CI-provided runtime configurations.

### Ⅳ. Describe how to verify it

The PR can be verified by running the GitHub Actions workflow `Seata E2E Test`.

The following matrix jobs passed in my fork:

- `E2E jdk8-mysql57-amd64`
- `E2E jdk11-mysql57-amd64`
- `E2E jdk17-mysql57-amd64`
- `E2E jdk11-mysql80-amd64`
- `E2E jdk17-mysql80-amd64`
- `E2E jdk17-mysql80-arm64`

Local verification performed:

```bash
cd e2e-test
mvn -q -pl e2e-test-builder,e2e-test-runner -am -DskipTests package
```
### Ⅴ. Special notes for reviews
Fixes https://github.com/apache/incubator-seata/issues/7178